### PR TITLE
Albermonte/issue10

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,8 +1,9 @@
 import { get } from "svelte/store";
 import { navigate } from "svelte-routing";
 
-import { client, consensus, height } from "nimiq-svelte-stores";
+import { client, consensus, height, newTransaction } from "nimiq-svelte-stores";
 import Nimiq from "@nimiq/core-web";
+import type { ClientTransactionDetails } from "@nimiq/core-web/types";
 
 import { CashlinkExtraData } from "../model";
 import {
@@ -34,23 +35,28 @@ export const isDev: boolean = process.env.dev;
  */
 const waitForFunds = async (txhash: string): Promise<void> => {
 	return new Promise(async (resolve) => {
-		try {
-			const tx = await client.getTransaction(txhash);
-			if (tx.state === "mined" || tx.state === "confirmed") resolve();
-		} catch (e) {
-			if (isDev) console.error(e);
-		}
-		const listener = await client.addTransactionListener(
-			(tx) => {
-				if (
-					tx.transactionHash.toHex() === txhash &&
-					(tx.state === "mined" || tx.state === "confirmed")
-				) {
-					client.removeListener(listener);
-					resolve();
+		const newTransactionUnsubscribe = newTransaction.subscribe(
+			(txDetails: ClientTransactionDetails) => {
+				if (txDetails && txDetails.transactionHash.toHex() === txhash) {
+					switch (txDetails.state) {
+						case Nimiq.Client.TransactionState.MINED:
+							// Transaction has been confirmed once
+							newTransactionUnsubscribe();
+							resolve();
+							break;
+						case Nimiq.Client.TransactionState.EXPIRED:
+							console.log(`${txDetails.transactionHash.toHex()} Expired`);
+							// TODO: catch error
+							throw new Error(`${txDetails.transactionHash.toHex()} Expired`);
+						case Nimiq.Client.TransactionState.INVALIDATED:
+							console.log(`${txDetails.transactionHash.toHex()} Invaldiated`);
+							// TODO: catch error
+							throw new Error(
+								`${txDetails.transactionHash.toHex()} Invaldiated`,
+							);
+					}
 				}
 			},
-			[get(wallet).address],
 		);
 	});
 };
@@ -92,8 +98,8 @@ export const waitForConsensusEstablished = async () => {
  */
 export const feeAmounts = {
 	free: 0,
-	standard: 138,
-	express: 276,
+	standard: 166 + 5, // Standard fee for Extended TX + Message length
+	express: 2 * (166 + 5), // Double than the Standard fee
 };
 
 /**


### PR DESCRIPTION
Fixes: #10

Changed client listener for newTransaction method from nimiq-svelte-stores library

Also fixes: #9, we were using the fee corresponding to a standard tx, but sending extended tx

Calculating the fee of a extended transacion (166) and adding the fee corresponding to the message (5) we have the new fee per tx.

If you want to know why 5:
[CashlinkExtraData.FUNDING](https://github.com/Albermonte/Nimiq-Multi-Cashlink/blob/16c6e63395057f2982fbe2343fa8e75b459978e4/src/model.ts#L23) is a Uint8Array with 5 elements, each element is 1 byte. 
The fee per byte is 1 Luna, `5 elements * 1 byte per element * 1 Luna per byte = 5 Lunas` for the whole message